### PR TITLE
Any order for column constraints

### DIFF
--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -782,6 +782,10 @@ func (p *parser) is(tokenTypes ...int) bool {
 	return false
 }
 
+func (p *parser) isNot(tokenTypes ...int) bool {
+	return !p.is(tokenTypes...)
+}
+
 func (p *parser) isNext(tokenTypes ...int) (t Token, err error) {
 
 	if !p.hasNext() {

--- a/engine/parser/parser_test.go
+++ b/engine/parser/parser_test.go
@@ -203,9 +203,15 @@ func TestOffset(t *testing.T) {
 }
 
 func TestUnique(t *testing.T) {
-	query := `CREATE TABLE pokemon (id BIGSERIAL, name TEXT UNIQUE NOT NULL)`
+	queries := []string{
+		`CREATE TABLE pokemon (id BIGSERIAL, name TEXT UNIQUE NOT NULL)`,
+		`CREATE TABLE pokemon (id BIGSERIAL, name TEXT NOT NULL UNIQUE)`,
+		`CREATE TABLE pokemon_name (id BIGINT, name VARCHAR(255) PRIMARY KEY NOT NULL UNIQUE)`,
+	}
 
-	parse(query, 1, t)
+	for _, q := range queries {
+		parse(q, 1, t)
+	}
 }
 
 func parse(query string, instructionNumber int, t *testing.T) []Instruction {


### PR DESCRIPTION
Currently `CREATE TABLE pokemon (id BIGSERIAL, name TEXT UNIQUE NOT NULL)` is parsed successfully, but `CREATE TABLE pokemon (id BIGSERIAL, name TEXT NOT NULL UNIQUE)` not.

In SQL order of column constraints does not matter.
This PR implements this.

