### PR TITLE
Fix default timestamp handling

### DIFF
--- a/engine/attribute.go
+++ b/engine/attribute.go
@@ -27,6 +27,8 @@ type Attribute struct {
 }
 
 func parseAttribute(decl *parser.Decl) (Attribute, error) {
+	const timeLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+
 	attr := Attribute{}
 
 	// Attribute name
@@ -57,7 +59,7 @@ func parseAttribute(decl *parser.Decl) (Attribute, error) {
 			switch typeDecl[i].Decl[0].Token {
 			case parser.LocalTimestampToken, parser.NowToken:
 				log.Debug("Setting default value to NOW() func !\n")
-				attr.defaultValue = func() interface{} { return time.Now() }
+				attr.defaultValue = func() interface{} { return time.Now().Format(timeLongFormat) }
 			default:
 				log.Debug("Setting default value to '%v'\n", typeDecl[i].Decl[0].Lexeme)
 				attr.defaultValue = typeDecl[i].Decl[0].Lexeme

--- a/engine/attribute.go
+++ b/engine/attribute.go
@@ -27,8 +27,6 @@ type Attribute struct {
 }
 
 func parseAttribute(decl *parser.Decl) (Attribute, error) {
-	const timeLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
-
 	attr := Attribute{}
 
 	// Attribute name
@@ -59,7 +57,7 @@ func parseAttribute(decl *parser.Decl) (Attribute, error) {
 			switch typeDecl[i].Decl[0].Token {
 			case parser.LocalTimestampToken, parser.NowToken:
 				log.Debug("Setting default value to NOW() func !\n")
-				attr.defaultValue = func() interface{} { return time.Now().Format(timeLongFormat) }
+				attr.defaultValue = func() interface{} { return time.Now().Format(parser.DateLongFormat) }
 			default:
 				log.Debug("Setting default value to '%v'\n", typeDecl[i].Decl[0].Lexeme)
 				attr.defaultValue = typeDecl[i].Decl[0].Lexeme

--- a/engine/insert.go
+++ b/engine/insert.go
@@ -89,7 +89,6 @@ func getRelation(e *Engine, intoDecl *parser.Decl) (*Relation, []*parser.Decl, e
 type f func() interface{}
 
 func insert(r *Relation, attributes []*parser.Decl, values []*parser.Decl, returnedID string) (int64, error) {
-	const timeLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 	var assigned = false
 	var id int64
 	var valuesindex int
@@ -105,7 +104,7 @@ func insert(r *Relation, attributes []*parser.Decl, values []*parser.Decl, retur
 				// Before adding value in tuple, check it's not a builtin func or arithmetic operation
 				switch values[x].Token {
 				case parser.NowToken:
-					t.Append(time.Now().Format(timeLongFormat))
+					t.Append(time.Now().Format(parser.DateLongFormat))
 				default:
 					t.Append(values[x].Lexeme)
 

--- a/engine/insert.go
+++ b/engine/insert.go
@@ -89,6 +89,7 @@ func getRelation(e *Engine, intoDecl *parser.Decl) (*Relation, []*parser.Decl, e
 type f func() interface{}
 
 func insert(r *Relation, attributes []*parser.Decl, values []*parser.Decl, returnedID string) (int64, error) {
+	const timeLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 	var assigned = false
 	var id int64
 	var valuesindex int
@@ -104,7 +105,7 @@ func insert(r *Relation, attributes []*parser.Decl, values []*parser.Decl, retur
 				// Before adding value in tuple, check it's not a builtin func or arithmetic operation
 				switch values[x].Token {
 				case parser.NowToken:
-					t.Append(time.Now())
+					t.Append(time.Now().Format(timeLongFormat))
 				default:
 					t.Append(values[x].Lexeme)
 

--- a/engine/parser/date.go
+++ b/engine/parser/date.go
@@ -5,12 +5,15 @@ import (
 	"time"
 )
 
+// DateLongFormat is same as time.Time#String(), except this does not include monotonic time section
+const DateLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+
+// DateShortFormat is a short format
+const DateShortFormat = "2006-Jan-02"
+
 // ParseDate intends to parse all SQL date format
 func ParseDate(data string) (*time.Time, error) {
-	const long = "2006-01-02 15:04:05.999999999 -0700 MST"
-	const short = "2006-Jan-02"
-
-	t, err := time.Parse(long, data)
+	t, err := time.Parse(DateLongFormat, data)
 	if err == nil {
 		return &t, nil
 	}
@@ -20,7 +23,7 @@ func ParseDate(data string) (*time.Time, error) {
 		return &t, nil
 	}
 
-	t, err = time.Parse(short, data)
+	t, err = time.Parse(DateShortFormat, data)
 	if err == nil {
 		return &t, nil
 	}

--- a/engine/update.go
+++ b/engine/update.go
@@ -91,6 +91,7 @@ func setExecutor(setDecl *parser.Decl) (map[string]interface{}, error) {
 }
 
 func updateValues(r *Relation, row int, values map[string]interface{}) error {
+	const timeLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 
 	for i := range r.table.attributes {
 		val, ok := values[r.table.attributes[i].name]
@@ -102,13 +103,14 @@ func updateValues(r *Relation, row int, values map[string]interface{}) error {
 		case "timestamp", "localtimestamp":
 			s, ok := val.(string)
 			if ok && (s == "current_timestamp" || s == "now()") {
-				r.rows[row].Values[i] = fmt.Sprintf("%s", time.Now())
-			} else {
-				r.rows[row].Values[i] = fmt.Sprintf("%v", val)
+				val = time.Now().Format(timeLongFormat)
 			}
-		default:
-			r.rows[row].Values[i] = fmt.Sprintf("%v", val)
+			// format time.Time into parsable string
+			if t, ok := val.(time.Time); ok {
+				val = t.Format(timeLongFormat)
+			}
 		}
+		r.rows[row].Values[i] = fmt.Sprintf("%v", val)
 	}
 
 	return nil

--- a/engine/update.go
+++ b/engine/update.go
@@ -91,8 +91,6 @@ func setExecutor(setDecl *parser.Decl) (map[string]interface{}, error) {
 }
 
 func updateValues(r *Relation, row int, values map[string]interface{}) error {
-	const timeLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
-
 	for i := range r.table.attributes {
 		val, ok := values[r.table.attributes[i].name]
 		if !ok {
@@ -103,11 +101,11 @@ func updateValues(r *Relation, row int, values map[string]interface{}) error {
 		case "timestamp", "localtimestamp":
 			s, ok := val.(string)
 			if ok && (s == "current_timestamp" || s == "now()") {
-				val = time.Now().Format(timeLongFormat)
+				val = time.Now()
 			}
 			// format time.Time into parsable string
 			if t, ok := val.(time.Time); ok {
-				val = t.Format(timeLongFormat)
+				val = t.Format(parser.DateLongFormat)
 			}
 		}
 		r.rows[row].Values[i] = fmt.Sprintf("%v", val)


### PR DESCRIPTION
Currently tests around `TIMESTAMP` are failing, and I found they're because format of `time.Time#String` has changed recently (maybe Go 1.9, which supports monotonic time).

In [document of `time.Time#String`](https://godoc.org/time#Time.String), explicit formatting is recommended to stabilize the result.
> The returned string is meant for debugging; for a stable serialized representation, use t.MarshalText, t.MarshalBinary, or t.Format with an explicit format string.

In this p-r, I modified/added string serializations in those three situations:
- insert record(s) with default values of "`DEFAULT CURRENT_TIMESTAMP`" columns, which inserts `time.Now()`
- insert record(s) with explicit `NOW()` value, which inserts `time.Now()`
- update record(s) with explicit `CURRENT_TIMESTAMP` / `NOW()` value, which inserts `time.Now()`
