### PR TITLE
add support for quoting names using backticks

### DIFF
--- a/engine/parser/lexer.go
+++ b/engine/parser/lexer.go
@@ -9,7 +9,7 @@ import (
 
 // SQL Tokens
 const (
-	// Ponctuation token
+	// Punctuation token
 
 	SpaceToken = iota
 	SemicolonToken
@@ -18,6 +18,7 @@ const (
 	BracketClosingToken
 	LeftDipleToken
 	RightDipleToken
+	BacktickToken
 
 	// QuoteToken
 
@@ -111,7 +112,7 @@ func (l *lexer) lex(instruction []byte) ([]Token, error) {
 	securityPos := 0
 
 	var matchers []Matcher
-	// Ponctuation Matcher
+	// Punctuation Matcher
 	matchers = append(matchers, l.MatchSpaceToken)
 	matchers = append(matchers, l.MatchSemicolonToken)
 	matchers = append(matchers, l.MatchCommaToken)
@@ -124,6 +125,7 @@ func (l *lexer) lex(instruction []byte) ([]Token, error) {
 	matchers = append(matchers, l.MatchDoubleQuoteToken)
 	matchers = append(matchers, l.MatchLeftDipleToken)
 	matchers = append(matchers, l.MatchRightDipleToken)
+	matchers = append(matchers, l.MatchBacktickToken)
 	// First order Matcher
 	matchers = append(matchers, l.MatchCreateToken)
 	matchers = append(matchers, l.MatchSelectToken)
@@ -193,7 +195,7 @@ func (l *lexer) lex(instruction []byte) ([]Token, error) {
 		}
 
 		if l.pos == securityPos {
-			log.Warning("Cannor lex <%s>, stuck at pos %d -> [%c]", l.instruction, l.pos, l.instruction[l.pos])
+			log.Warning("Cannot lex <%s>, stuck at pos %d -> [%c]", l.instruction, l.pos, l.instruction[l.pos])
 			return nil, fmt.Errorf("Cannot lex instruction. Syntax error near %s", instruction[l.pos:])
 		}
 		securityPos = l.pos
@@ -471,6 +473,10 @@ func (l *lexer) MatchLeftDipleToken() bool {
 
 func (l *lexer) MatchRightDipleToken() bool {
 	return l.MatchSingle('>', RightDipleToken)
+}
+
+func (l *lexer) MatchBacktickToken() bool {
+	return l.MatchSingle('`', BacktickToken)
 }
 
 // 2015-09-10 14:03:09.444695269 +0200 CEST);

--- a/engine/parser/lexer_test.go
+++ b/engine/parser/lexer_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLexerSimple(t *testing.T) {
-	query := `CREATE TABLE account`
+	query := `CREATE TABLE `+"`"+`account`+"`"+``
 
 	lexer := lexer{}
 	decls, err := lexer.lex([]byte(query))
@@ -14,8 +14,8 @@ func TestLexerSimple(t *testing.T) {
 		t.Fatalf("Cannot lex <%s> string", query)
 	}
 
-	if len(decls) != 5 {
-		t.Fatalf("Lexing failed, expected 5 tokens, got %d", len(decls))
+	if len(decls) != 7 {
+		t.Fatalf("Lexing failed, expected 7 tokens, got %d", len(decls))
 	}
 }
 

--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -454,8 +454,10 @@ func (p *parser) parseBuiltinFunc() (*Decl, error) {
 // foo
 func (p *parser) parseAttribute() (*Decl, error) {
 	quoted := false
+	quoteToken := DoubleQuoteToken
 
-	if p.is(DoubleQuoteToken) {
+	if p.is(DoubleQuoteToken) || p.is(BacktickToken) {
+		quoteToken = p.cur().Token
 		quoted = true
 		if err := p.next(); err != nil {
 			return nil, err
@@ -472,7 +474,7 @@ func (p *parser) parseAttribute() (*Decl, error) {
 
 	if quoted {
 		// Check there is a closing quote
-		if _, err := p.mustHaveNext(DoubleQuoteToken); err != nil {
+		if _, err := p.mustHaveNext(quoteToken); err != nil {
 			log.Debug("parseAttribute: Missing closing quote")
 			return nil, err
 		}
@@ -506,9 +508,11 @@ func (p *parser) parseAttribute() (*Decl, error) {
 // "table"
 func (p *parser) parseQuotedToken() (*Decl, error) {
 	quoted := false
+	quoteToken := DoubleQuoteToken
 
-	if p.is(DoubleQuoteToken) {
+	if p.is(DoubleQuoteToken) || p.is(BacktickToken){
 		quoted = true
+		quoteToken = p.cur().Token
 		if err := p.next(); err != nil {
 			return nil, err
 		}
@@ -523,7 +527,7 @@ func (p *parser) parseQuotedToken() (*Decl, error) {
 	if quoted {
 
 		// Check there is a closing quote
-		if _, err := p.mustHaveNext(DoubleQuoteToken); err != nil {
+		if _, err := p.mustHaveNext(quoteToken); err != nil {
 			return nil, err
 		}
 	}

--- a/engine/parser/parser_test.go
+++ b/engine/parser/parser_test.go
@@ -41,6 +41,21 @@ func TestParserComplete(t *testing.T) {
 	parse(query, 1, t)
 }
 
+func TestParserCompleteWithBacktickQuotes(t *testing.T) {
+	query := `CREATE TABLE `+"`"+`user`+"`"+`
+	(
+		`+"`"+`id`+"`"+` INT PRIMARY KEY,
+		`+"`"+`last_name`+"`"+` TEXT,
+		`+"`"+`first_name`+"`"+` TEXT,
+		`+"`"+`email`+"`"+` TEXT,
+		`+"`"+`birth_date`+"`"+` DATE,
+		`+"`"+`country`+"`"+` TEXT,
+		`+"`"+`town`+"`"+` TEXT,
+		`+"`"+`zip_code`+"`"+` TEXT
+	)`
+	parse(query, 1, t)
+}
+
 // func TestParserCreateTableWithVarchar(t *testing.T) {
 // 	query := `CREATE TABLE user
 // 	(
@@ -75,6 +90,11 @@ func TestSelectAttributeWithQuotedTable(t *testing.T) {
 	parse(query, 1, t)
 }
 
+func TestSelectAttributeWithBacktickQuotedTable(t *testing.T) {
+	query := `SELECT `+"`"+`account`+"`"+`.id FROM account WHERE email = 'foo@bar.com'`
+	parse(query, 1, t)
+}
+
 func TestSelectAllFromTable(t *testing.T) {
 	query := `SELECT "account".* FROM account WHERE email = 'foo@bar.com'`
 	parse(query, 1, t)
@@ -90,6 +110,14 @@ func TestSelectQuotedTableName(t *testing.T) {
 	parse(query, 1, t)
 
 	query = `SELECT * FROM "account"`
+	parse(query, 1, t)
+}
+
+func TestSelectBacktickQuotedTableName(t *testing.T) {
+	query := `SELECT * FROM `+"`"+`account`+"`"+` WHERE 1`
+	parse(query, 1, t)
+
+	query = `SELECT * FROM `+"`"+`account`+"`"+``
 	parse(query, 1, t)
 }
 
@@ -112,6 +140,11 @@ func TestInsertNumber(t *testing.T) {
 
 func TestInsertNumberWithQuote(t *testing.T) {
 	query := `INSERT INTO "account" ('email', 'password', 'age') VALUES ('foo@bar.com', 'tititoto', 4)`
+	parse(query, 1, t)
+}
+
+func TestInsertNumberWithBacktickQuote(t *testing.T) {
+	query := `INSERT INTO `+"`"+`account`+"`"+` ('email', 'password', 'age') VALUES ('foo@bar.com', 'tititoto', 4)`
 	parse(query, 1, t)
 }
 


### PR DESCRIPTION
This patch will add backticks as a possible quote char around
names. It will not add the possibility to us special characters
as names, as would be possible in SQL using backticks. It is just
there because a lot of schemas are created using backticks despite
there being no special chars in the name. Those schemas and queries
could not be parsed by ramsql.