### PR TITLE
add support for comparing dates

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -276,6 +276,120 @@ func TestBatch(t *testing.T) {
 
 }
 
+func TestCompareDateGT(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestCompareDateGT")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE comp (dat DATE);")
+	if err != nil {
+		t.Fatalf("Cannot create table: %s", err)
+	}
+
+	_, err = db.Exec("INSERT INTO comp (dat) VALUES ('2018-01-01')")
+	if err != nil {
+		t.Fatal("Cannot insert value")
+	}
+	_, err = db.Exec("INSERT INTO comp (dat) VALUES ('2019-01-01')")
+	if err != nil {
+		t.Fatal("Cannot insert value")
+	}
+	_, err = db.Exec("INSERT INTO comp (dat) VALUES ('2020-01-01')")
+	if err != nil {
+		t.Fatal("Cannot insert value")
+	}
+
+	query := "SELECT dat FROM comp WHERE dat > '2018-03-03'"
+
+	rows, err := db.Query(query, )
+	if err != nil {
+		t.Fatalf("sql.Query: %s", err)
+	}
+
+	var nb int
+	for rows.Next() {
+		var dat time.Time
+		if err := rows.Scan(&dat); err != nil {
+			t.Fatalf("Cannot scan row: %s", err)
+		}
+		unwantedDate, err := time.Parse("2006-01-02", "2018-01-01")
+		if err != nil {
+			t.Fatal("Cannot parse unwanted date", err)
+		}
+		if dat.Equal(unwantedDate) {
+			t.Fatalf("Unwanted row: %v", dat)
+		}
+
+		nb++
+	}
+
+	if nb != 2 {
+		t.Fatalf("Unwanted number of rows %d", nb)
+	}
+
+}
+
+func TestCompareDateLT(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestCompareDateLT")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE comp (dat DATE);")
+	if err != nil {
+		t.Fatalf("Cannot create table: %s", err)
+	}
+
+	_, err = db.Exec("INSERT INTO comp (dat) VALUES ('2018-01-01')")
+	if err != nil {
+		t.Fatal("Cannot insert value")
+	}
+	_, err = db.Exec("INSERT INTO comp (dat) VALUES ('2019-01-01')")
+	if err != nil {
+		t.Fatal("Cannot insert value")
+	}
+	_, err = db.Exec("INSERT INTO comp (dat) VALUES ('2020-01-01')")
+	if err != nil {
+		t.Fatal("Cannot insert value")
+	}
+
+	query := "SELECT dat FROM comp WHERE dat < '2019-03-03'"
+
+	rows, err := db.Query(query, )
+	if err != nil {
+		t.Fatalf("sql.Query: %s", err)
+	}
+
+	var nb int
+	for rows.Next() {
+		var dat time.Time
+		if err := rows.Scan(&dat); err != nil {
+			t.Fatalf("Cannot scan row: %s", err)
+		}
+		unwantedDate, err := time.Parse("2006-01-02", "2020-01-01")
+		if err != nil {
+			t.Fatal("Cannot parse unwanted date", err)
+		}
+		if dat.Equal(unwantedDate) {
+			t.Fatalf("Unwanted row: %v", dat)
+		}
+
+		nb++
+	}
+
+	if nb != 2 {
+		t.Fatalf("Unwanted number of rows %d", nb)
+	}
+
+}
+
 func TestDate(t *testing.T) {
 	log.UseTestLogger(t)
 

--- a/engine/parser/date.go
+++ b/engine/parser/date.go
@@ -11,6 +11,8 @@ const DateLongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 // DateShortFormat is a short format
 const DateShortFormat = "2006-Jan-02"
 
+const DateNumberFormat = "2006-01-02"
+
 // ParseDate intends to parse all SQL date format
 func ParseDate(data string) (*time.Time, error) {
 	t, err := time.Parse(DateLongFormat, data)
@@ -24,6 +26,11 @@ func ParseDate(data string) (*time.Time, error) {
 	}
 
 	t, err = time.Parse(DateShortFormat, data)
+	if err == nil {
+		return &t, nil
+	}
+
+	t, err = time.Parse(DateNumberFormat, data)
 	if err == nil {
 		return &t, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/proullon/ramsql
+
+require (
+	github.com/go-gorp/gorp v2.0.0+incompatible
+	github.com/lib/pq v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/go-gorp/gorp v2.0.0+incompatible h1:dIQPsBtl6/H1MjVseWuWPXa7ET4p6Dve4j3Hg+UjqYw=
+github.com/go-gorp/gorp v2.0.0+incompatible/go.mod h1:7IfkAQnO7jfT/9IQ3R9wL1dFhukN6aQxzKTHnkxzA/E=
+github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
+github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=


### PR DESCRIPTION
This patch enables comparing dates using > and <.

A feature that is still missing is is using >= and <=. This is
a more fundamental change that should follow in another
patch in the future.