### PR TITLE
add <= and >=

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -499,6 +499,62 @@ func TestAnd(t *testing.T) {
 
 }
 
+func TestGreaterThanOrEqualAndLessThanOrEqual(t *testing.T) {
+	log.UseTestLogger(t)
+
+	batch := []string{
+		`CREATE TABLE user (name TEXT, surname TEXT, age INT);`,
+		`INSERT INTO user (name, surname, age) VALUES (Foo, Bar, 20);`,
+		`INSERT INTO user (name, surname, age) VALUES (John, Doe, 32);`,
+		`INSERT INTO user (name, surname, age) VALUES (Jane, Doe, 33);`,
+		`INSERT INTO user (name, surname, age) VALUES (Joe, Doe, 10);`,
+		`INSERT INTO user (name, surname, age) VALUES (Homer, Simpson, 40);`,
+		`INSERT INTO user (name, surname, age) VALUES (Marge, Simpson, 40);`,
+		`INSERT INTO user (name, surname, age) VALUES (Bruce, Wayne, 3333);`,
+	}
+
+	db, err := sql.Open("ramsql", "TestGreaterThanOrEqualAndLessThanOrEqual")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	for _, b := range batch {
+		_, err = db.Exec(b)
+		if err != nil {
+			t.Fatalf("sql.Exec: Error: %s\n", err)
+		}
+	}
+
+	query := `SELECT * FROM user
+			WHERE user.age <= 40
+			AND age >= 32`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("sql.Query: %s", err)
+	}
+
+	var nb int
+	for rows.Next() {
+		var name, surname string
+		var age int
+		if err := rows.Scan(&name, &surname, &age); err != nil {
+			t.Fatalf("Cannot scan row: %s", err)
+		}
+		if age < 32 || age > 40 {
+			t.Fatalf("Unwanted row: %s %s %d", name, surname, age)
+		}
+
+		nb++
+	}
+
+	if nb != 4 {
+		t.Fatalf("Expected 4 rows, got %d", nb)
+	}
+
+}
+
 func TestGreaterThanAndLessThan(t *testing.T) {
 	log.UseTestLogger(t)
 

--- a/engine/operator.go
+++ b/engine/operator.go
@@ -20,6 +20,10 @@ func NewOperator(token int, lexeme string) (Operator, error) {
 		return lessThanOperator, nil
 	case parser.RightDipleToken:
 		return greaterThanOperator, nil
+	case parser.LessOrEqualToken:
+		return lessOrEqualOperator, nil
+	case parser.GreaterOrEqualToken:
+		return greaterOrEqualOperator, nil
 	}
 
 	return nil, fmt.Errorf("Operator '%s' does not exist", lexeme)
@@ -102,6 +106,14 @@ func greaterThanOperator(leftValue Value, rightValue Value) bool {
 	}
 
 	return leftDate.After(rightDate)
+}
+
+func lessOrEqualOperator(leftValue Value, rightValue Value) bool {
+	return lessThanOperator(leftValue, rightValue) || equalityOperator(leftValue, rightValue)
+}
+
+func greaterOrEqualOperator(leftValue Value, rightValue Value) bool {
+	return greaterThanOperator(leftValue, rightValue) || equalityOperator(leftValue, rightValue)
 }
 
 func lessThanOperator(leftValue Value, rightValue Value) bool {

--- a/engine/parser/lexer.go
+++ b/engine/parser/lexer.go
@@ -18,6 +18,8 @@ const (
 	BracketClosingToken
 	LeftDipleToken
 	RightDipleToken
+	LessOrEqualToken
+	GreaterOrEqualToken
 	BacktickToken
 
 	// QuoteToken
@@ -123,6 +125,8 @@ func (l *lexer) lex(instruction []byte) ([]Token, error) {
 	matchers = append(matchers, l.MatchEqualityToken)
 	matchers = append(matchers, l.MatchPeriodToken)
 	matchers = append(matchers, l.MatchDoubleQuoteToken)
+	matchers = append(matchers, l.MatchLessOrEqualToken)
+	matchers = append(matchers, l.MatchGreaterOrEqualToken)
 	matchers = append(matchers, l.MatchLeftDipleToken)
 	matchers = append(matchers, l.MatchRightDipleToken)
 	matchers = append(matchers, l.MatchBacktickToken)
@@ -473,6 +477,14 @@ func (l *lexer) MatchLeftDipleToken() bool {
 
 func (l *lexer) MatchRightDipleToken() bool {
 	return l.MatchSingle('>', RightDipleToken)
+}
+
+func (l *lexer) MatchLessOrEqualToken() bool {
+	return l.Match([]byte("<="), LessOrEqualToken)
+}
+
+func (l *lexer) MatchGreaterOrEqualToken() bool {
+	return l.Match([]byte(">="), GreaterOrEqualToken)
 }
 
 func (l *lexer) MatchBacktickToken() bool {

--- a/engine/parser/lexer_test.go
+++ b/engine/parser/lexer_test.go
@@ -28,3 +28,17 @@ func TestParseDate(t *testing.T) {
 		t.Fatalf("Cannot parse %s: %s", data, err)
 	}
 }
+
+func TestLexerWithGTOEandLTOEOperator(t *testing.T) {
+	query := `SELECT FROM foo WHERE 1 >= 1 AND 2 <= 3`
+
+	lexer := lexer{}
+	decls, err := lexer.lex([]byte(query))
+	if err != nil {
+		t.Fatalf("Cannot lex <%s> string", query)
+	}
+
+	if len(decls) != 21 {
+		t.Fatalf("Lexing failed, expected 21 tokens, got %d", len(decls))
+	}
+}

--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -560,7 +560,7 @@ func (p *parser) parseCondition() (*Decl, error) {
 	}
 
 	switch p.cur().Token {
-	case EqualityToken, LeftDipleToken, RightDipleToken:
+	case EqualityToken, LeftDipleToken, RightDipleToken, LessOrEqualToken, GreaterOrEqualToken:
 		decl, err := p.consumeToken(p.cur().Token)
 		if err != nil {
 			return nil, err

--- a/engine/select.go
+++ b/engine/select.go
@@ -363,7 +363,7 @@ func whereExecutor2(e *Engine, decl []*parser.Decl, fromTableName string) (Predi
 	}
 
 	switch cond.Decl[0].Token {
-	case parser.IsToken, parser.InToken, parser.EqualityToken, parser.LeftDipleToken, parser.RightDipleToken:
+	case parser.IsToken, parser.InToken, parser.EqualityToken, parser.LeftDipleToken, parser.RightDipleToken, parser.LessOrEqualToken, parser.GreaterOrEqualToken:
 		break
 	default:
 		fromTableName = cond.Decl[0].Lexeme
@@ -444,8 +444,8 @@ func whereExecutor(whereDecl *parser.Decl, fromTableName string) ([]Predicate, e
 		}
 
 		switch cond.Decl[0].Token {
-		case parser.EqualityToken, parser.LeftDipleToken, parser.RightDipleToken:
-			log.Debug("whereExecutor: it's = < >\n")
+		case parser.EqualityToken, parser.LeftDipleToken, parser.RightDipleToken, parser.LessOrEqualToken, parser.GreaterOrEqualToken:
+			log.Debug("whereExecutor: it's = < > <= >=\n")
 			break
 		case parser.InToken:
 			log.Debug("whereExecutor: it's IN\n")


### PR DESCRIPTION
I decided to add those operators as separate tokens instead of using the existing tokens in the parse step. This way the integration is way easier and one can argue that <= and >= are indeed single tokens in the context of SQL.