### PR TITLE
Export NewDriver func.

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	sql.Register("ramsql", newDriver())
+	sql.Register("ramsql", NewDriver())
 	log.SetLevel(log.WarningLevel)
 }
 
@@ -40,7 +40,8 @@ type Driver struct {
 	servers map[string]*Server
 }
 
-func newDriver() *Driver {
+// NewDriver creates a driver object
+func NewDriver() *Driver {
 	d := &Driver{}
 	d.servers = make(map[string]*Server)
 	return d


### PR DESCRIPTION
So we can use this in an SQL interceptor project like
https://github.com/ngrok/sqlmw.

`sqlmw` needs us to use the driver object to be intercepted.
And we currently can't create the driver.
