### PR TITLE
Add 'distinct' (not equals) operator.

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -499,6 +499,62 @@ func TestAnd(t *testing.T) {
 
 }
 
+func TestEqualAndDistinct(t *testing.T) {
+	log.UseTestLogger(t)
+
+	batch := []string{
+		`CREATE TABLE user (name TEXT, surname TEXT, age INT);`,
+		`INSERT INTO user (name, surname, age) VALUES ('Foo', 'Bar', 20);`,
+		`INSERT INTO user (name, surname, age) VALUES ('John', 'Doe', 32);`,
+		`INSERT INTO user (name, surname, age) VALUES ('Jane', 'Doe', 33);`,
+		`INSERT INTO user (name, surname, age) VALUES ('Joe', 'Doe', 10);`,
+		`INSERT INTO user (name, surname, age) VALUES ('Homer', 'Simpson', 40);`,
+		`INSERT INTO user (name, surname, age) VALUES ('Marge', 'Simpson', 40);`,
+		`INSERT INTO user (name, surname, age) VALUES ('Bruce', 'Wayne', 3333);`,
+	}
+
+	db, err := sql.Open("ramsql", "TestEqualAndDistinct")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	for _, b := range batch {
+		_, err = db.Exec(b)
+		if err != nil {
+			t.Fatalf("sql.Exec: Error: %s\n", err)
+		}
+	}
+
+	query := `SELECT * FROM user
+			WHERE user.surname = 'Doe'
+			AND user.name <> 'Jane'`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("sql.Query: %s", err)
+	}
+
+	var nb int
+	for rows.Next() {
+		var name, surname string
+		var age int
+		if err := rows.Scan(&name, &surname, &age); err != nil {
+			t.Fatalf("Cannot scan row: %s", err)
+		}
+		if name == "Jane" || surname != "Doe" {
+			t.Fatalf("Unwanted row: %s %s %d", name, surname, age)
+		}
+
+		nb++
+	}
+
+	if nb != 2 {
+		t.Fatalf("Expected 2 rows, got %d", nb)
+	}
+
+}
+
 func TestGreaterThanOrEqualAndLessThanOrEqual(t *testing.T) {
 	log.UseTestLogger(t)
 

--- a/engine/operator.go
+++ b/engine/operator.go
@@ -16,6 +16,8 @@ func NewOperator(token int, lexeme string) (Operator, error) {
 	switch token {
 	case parser.EqualityToken:
 		return equalityOperator, nil
+	case parser.DistinctnessToken:
+		return distinctnessOperator, nil
 	case parser.LeftDipleToken:
 		return lessThanOperator, nil
 	case parser.RightDipleToken:
@@ -164,6 +166,16 @@ func lessThanOperator(leftValue Value, rightValue Value) bool {
 func equalityOperator(leftValue Value, rightValue Value) bool {
 
 	if fmt.Sprintf("%v", leftValue.v) == rightValue.lexeme {
+		return true
+	}
+
+	return false
+}
+
+// DistinctnessOperator checks if given value are distinct
+func distinctnessOperator(leftValue Value, rightValue Value) bool {
+
+	if fmt.Sprintf("%v", leftValue.v) != rightValue.lexeme {
 		return true
 	}
 

--- a/engine/parser/lexer.go
+++ b/engine/parser/lexer.go
@@ -28,6 +28,7 @@ const (
 	SimpleQuoteToken
 	StarToken
 	EqualityToken
+	DistinctnessToken
 	PeriodToken
 
 	// First order Token
@@ -123,6 +124,7 @@ func (l *lexer) lex(instruction []byte) ([]Token, error) {
 	matchers = append(matchers, l.MatchStarToken)
 	matchers = append(matchers, l.MatchSimpleQuoteToken)
 	matchers = append(matchers, l.MatchEqualityToken)
+	matchers = append(matchers, l.MatchDistinctnessToken)
 	matchers = append(matchers, l.MatchPeriodToken)
 	matchers = append(matchers, l.MatchDoubleQuoteToken)
 	matchers = append(matchers, l.MatchLessOrEqualToken)
@@ -469,6 +471,10 @@ func (l *lexer) MatchStarToken() bool {
 
 func (l *lexer) MatchEqualityToken() bool {
 	return l.MatchSingle('=', EqualityToken)
+}
+
+func (l *lexer) MatchDistinctnessToken() bool {
+	return l.Match([]byte("<>"), DistinctnessToken)
 }
 
 func (l *lexer) MatchLeftDipleToken() bool {

--- a/engine/parser/lexer_test.go
+++ b/engine/parser/lexer_test.go
@@ -42,3 +42,17 @@ func TestLexerWithGTOEandLTOEOperator(t *testing.T) {
 		t.Fatalf("Lexing failed, expected 21 tokens, got %d", len(decls))
 	}
 }
+
+func TestLexerWithNEOperator(t *testing.T) {
+	query := `SELECT FROM foo WHERE 0 <> 1 AND 2 <> 3`
+
+	lexer := lexer{}
+	decls, err := lexer.lex([]byte(query))
+	if err != nil {
+		t.Fatalf("Cannot lex <%s> string", query)
+	}
+
+	if len(decls) != 21 {
+		t.Fatalf("Lexing failed, expected 21 tokens, got %d", len(decls))
+	}
+}

--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -560,7 +560,7 @@ func (p *parser) parseCondition() (*Decl, error) {
 	}
 
 	switch p.cur().Token {
-	case EqualityToken, LeftDipleToken, RightDipleToken, LessOrEqualToken, GreaterOrEqualToken:
+	case EqualityToken, DistinctnessToken, LeftDipleToken, RightDipleToken, LessOrEqualToken, GreaterOrEqualToken:
 		decl, err := p.consumeToken(p.cur().Token)
 		if err != nil {
 			return nil, err

--- a/engine/select.go
+++ b/engine/select.go
@@ -363,7 +363,7 @@ func whereExecutor2(e *Engine, decl []*parser.Decl, fromTableName string) (Predi
 	}
 
 	switch cond.Decl[0].Token {
-	case parser.IsToken, parser.InToken, parser.EqualityToken, parser.LeftDipleToken, parser.RightDipleToken, parser.LessOrEqualToken, parser.GreaterOrEqualToken:
+	case parser.IsToken, parser.InToken, parser.EqualityToken, parser.DistinctnessToken, parser.LeftDipleToken, parser.RightDipleToken, parser.LessOrEqualToken, parser.GreaterOrEqualToken:
 		break
 	default:
 		fromTableName = cond.Decl[0].Lexeme
@@ -444,8 +444,8 @@ func whereExecutor(whereDecl *parser.Decl, fromTableName string) ([]Predicate, e
 		}
 
 		switch cond.Decl[0].Token {
-		case parser.EqualityToken, parser.LeftDipleToken, parser.RightDipleToken, parser.LessOrEqualToken, parser.GreaterOrEqualToken:
-			log.Debug("whereExecutor: it's = < > <= >=\n")
+		case parser.EqualityToken, parser.DistinctnessToken, parser.LeftDipleToken, parser.RightDipleToken, parser.LessOrEqualToken, parser.GreaterOrEqualToken:
+			log.Debug("whereExecutor: it's = <> < > <= >=\n")
 			break
 		case parser.InToken:
 			log.Debug("whereExecutor: it's IN\n")


### PR DESCRIPTION
This pull request resolves #44 by adding support for the standard `<>` SQL operator.