### PR TITLE
Support the = NULL syntax in UPDATE statements

### DIFF
--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -186,7 +186,7 @@ func (p *parser) parseUpdate() (*Instruction, error) {
 			break
 		}
 
-		attributeDecl, err := p.parseCondition()
+		attributeDecl, err := p.parseAttribution()
 		if err != nil {
 			return nil, err
 		}
@@ -510,7 +510,7 @@ func (p *parser) parseQuotedToken() (*Decl, error) {
 	quoted := false
 	quoteToken := DoubleQuoteToken
 
-	if p.is(DoubleQuoteToken) || p.is(BacktickToken){
+	if p.is(DoubleQuoteToken) || p.is(BacktickToken) {
 		quoted = true
 		quoteToken = p.cur().Token
 		if err := p.next(); err != nil {
@@ -534,6 +534,42 @@ func (p *parser) parseQuotedToken() (*Decl, error) {
 
 	p.next()
 	return decl, nil
+}
+
+func (p *parser) parseAttribution() (*Decl, error) {
+
+	// Attribute
+	attributeDecl, err := p.parseAttribute()
+	if err != nil {
+		return nil, err
+	}
+
+	// Equals operator
+	if p.cur().Token == EqualityToken {
+		decl, err := p.consumeToken(p.cur().Token)
+		if err != nil {
+			return nil, err
+		}
+		attributeDecl.Add(decl)
+	}
+
+	// Value
+	if p.cur().Token == NullToken {
+		log.Debug("parseAttribution: NullToken\n")
+		nullDecl, err := p.consumeToken(NullToken)
+		if err != nil {
+			return nil, err
+		}
+		attributeDecl.Add(nullDecl)
+	} else {
+		valueDecl, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+		attributeDecl.Add(valueDecl)
+	}
+
+	return attributeDecl, nil
 }
 
 func (p *parser) parseCondition() (*Decl, error) {

--- a/engine/update.go
+++ b/engine/update.go
@@ -84,7 +84,11 @@ func setExecutor(setDecl *parser.Decl) (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 
 	for _, attr := range setDecl.Decl {
-		values[attr.Lexeme] = attr.Decl[1].Lexeme
+		if attr.Decl[1].Token == parser.NullToken {
+			values[attr.Lexeme] = nil
+		} else {
+			values[attr.Lexeme] = attr.Decl[1].Lexeme
+		}
 	}
 
 	return values, nil

--- a/engine/update_test.go
+++ b/engine/update_test.go
@@ -161,3 +161,57 @@ func TestUpdateNotNull(t *testing.T) {
 	}
 
 }
+
+func TestUpdateToNull(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestUpdateToNull")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE account (id INT AUTOINCREMENT, email TEXT, creation_date TIMESTAMP WITH TIME ZONE)")
+	if err != nil {
+		t.Fatalf("sql.Exec: Error: %s\n", err)
+	}
+
+	_, err = db.Exec("INSERT INTO account ('email') VALUES ('foo@bar.com')")
+	if err != nil {
+		t.Fatalf("Cannot insert into table account: %s", err)
+	}
+
+	row1 := db.QueryRow("SELECT email FROM account WHERE id = 1")
+	if row1 == nil {
+		t.Fatalf("sql.Query failed")
+	}
+
+	var email1 *string
+	err = row1.Scan(&email1)
+	if err != nil {
+		t.Fatalf("row.Scan: %s", err)
+	}
+	if email1 == nil {
+		t.Fatalf("expected 'foo@bar.com' email, but got NULL")
+	}
+
+	_, err = db.Exec("UPDATE account SET email = NULL WHERE id = 1")
+	if err != nil {
+		t.Fatalf("Cannot update table account: %s", err)
+	}
+
+	row2 := db.QueryRow("SELECT email FROM account WHERE id = 1")
+	if row2 == nil {
+		t.Fatalf("sql.Query failed")
+	}
+
+	var email2 *string
+	err = row2.Scan(&email2)
+	if err != nil {
+		t.Fatalf("row.Scan: %s", err)
+	}
+	if email2 != nil {
+		t.Fatalf("expected NULL email, but got '%v'", *email2)
+	}
+
+}


### PR DESCRIPTION
Attributions like `= NULL` were refused on `SET` parts of `UPDATE` statements because they were handled as if they were conditions. The `= NULL` syntax is illegal for conditions, but legal for attributions.

In order to fix it, I created a `parseAttribution` method (which accepts `= NULL`) and used it instead of `parseCondition` for parsing attributions in the `SET` parts of `UPDATE` statements.

Closes #46