### PR TITLE
Support the NOT IN syntax in SELECT statements

### DIFF
--- a/driver/in_test.go
+++ b/driver/in_test.go
@@ -60,3 +60,57 @@ func TestIn(t *testing.T) {
 	}
 
 }
+
+func TestNotIn(t *testing.T) {
+	log.UseTestLogger(t)
+
+	batch := []string{
+		`CREATE TABLE user (name TEXT, surname TEXT, age INT);`,
+		`INSERT INTO user (name, surname, age) VALUES (Foo, Bar, 20);`,
+		`INSERT INTO user (name, surname, age) VALUES (John, Doe, 32);`,
+		`INSERT INTO user (name, surname, age) VALUES (Jane, Doe, 33);`,
+		`INSERT INTO user (name, surname, age) VALUES (Joe, Doe, 10);`,
+		`INSERT INTO user (name, surname, age) VALUES (Homer, Simpson, 40);`,
+		`INSERT INTO user (name, surname, age) VALUES (Marge, Simpson, 40);`,
+		`INSERT INTO user (name, surname, age) VALUES (Bruce, Wayne, 3333);`,
+	}
+
+	db, err := sql.Open("ramsql", "TestNotIn")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	for _, b := range batch {
+		_, err = db.Exec(b)
+		if err != nil {
+			t.Fatalf("sql.Exec: Error: %s\n", err)
+		}
+	}
+
+	query := `SELECT * FROM user WHERE user.surname NOT IN ('Doe', 'Simpson')`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatalf("sql.Query: %s", err)
+	}
+
+	var nb int
+	for rows.Next() {
+		var name, surname string
+		var age int
+		if err := rows.Scan(&name, &surname, &age); err != nil {
+			t.Fatalf("Cannot scan row: %s", err)
+		}
+		if surname == "Doe" || surname == "Simpson" {
+			t.Fatalf("Unwanted row: %s %s %d", name, surname, age)
+		}
+
+		nb++
+	}
+
+	if nb != 2 {
+		t.Fatalf("Expected 2 rows, got %d", nb)
+	}
+
+}

--- a/engine/operator.go
+++ b/engine/operator.go
@@ -38,7 +38,7 @@ func convToDate(t interface{}) (time.Time, error) {
 		log.Debug("convToDate> unexpected type %T\n", t)
 		return time.Time{}, fmt.Errorf("unexpected internal type %T", t)
 	case string:
-		d, err :=parser.ParseDate(string(t))
+		d, err := parser.ParseDate(string(t))
 		if err != nil {
 			return time.Time{}, fmt.Errorf("cannot parse date %v", t)
 		}
@@ -203,6 +203,10 @@ func inOperator(leftValue Value, rightValue Value) bool {
 	}
 
 	return false
+}
+
+func notInOperator(leftValue Value, rightValue Value) bool {
+	return !inOperator(leftValue, rightValue)
 }
 
 func isNullOperator(leftValue Value, rightValue Value) bool {

--- a/engine/parser/parser.go
+++ b/engine/parser/parser.go
@@ -574,6 +574,24 @@ func (p *parser) parseCondition() (*Decl, error) {
 		}
 		attributeDecl.Add(inDecl)
 		return attributeDecl, nil
+	case NotToken:
+		notDecl, err := p.consumeToken(p.cur().Token)
+		if err != nil {
+			return nil, err
+		}
+
+		if p.cur().Token != InToken {
+			return nil, fmt.Errorf("expected IN after NOT")
+		}
+
+		inDecl, err := p.parseIn()
+		if err != nil {
+			return nil, err
+		}
+		notDecl.Add(inDecl)
+
+		attributeDecl.Add(notDecl)
+		return attributeDecl, nil
 	case IsToken:
 		log.Debug("parseCondition: IsToken\n")
 		decl, err := p.consumeToken(IsToken)


### PR DESCRIPTION
`NOT IN` was not accepted as a valid condition by the `parseCondition` method.

I changed the method to accept `NOT` as a valid operator, with the `IN` operation nested right within.

The AST branch generated by parsing `baz NOT IN ('qux', 'shme')` now looks like the following:

    baz
    | NOT
    | | IN
    | | | 'qux'
    | | | 'shme'

I also made changes to support the `NOT IN` operation in the execution phase using the new `notInOperator` function.

Closes #48 