### PR TITLE
Support multiple value lists on INSERT statements

### DIFF
--- a/engine/insert.go
+++ b/engine/insert.go
@@ -19,14 +19,19 @@ import (
             |-> first_name
             |-> email
     |-> VALUES
-        |-> Roullon
-        |-> Pierre
-        |-> pierre.roullon@gmail.com
+        |-> (
+            |-> Roullon
+            |-> Pierre
+            |-> pierre.roullon@gmail.com
+    |-> RETURNING
+            |-> email
+
 */
 func insertIntoTableExecutor(e *Engine, insertDecl *parser.Decl, conn protocol.EngineConn) error {
 
 	// Get table and concerned attributes and write lock it
-	r, attributes, err := getRelation(e, insertDecl.Decl[0])
+	intoDecl := insertDecl.Decl[0]
+	r, attributes, err := getRelation(e, intoDecl)
 	if err != nil {
 		return err
 	}
@@ -38,25 +43,35 @@ func insertIntoTableExecutor(e *Engine, insertDecl *parser.Decl, conn protocol.E
 	if len(insertDecl.Decl) > 2 {
 		for i := range insertDecl.Decl {
 			if insertDecl.Decl[i].Token == parser.ReturningToken {
-				returnedID = insertDecl.Decl[i].Lexeme
+				returningDecl := insertDecl.Decl[i]
+				returnedID = returningDecl.Lexeme
 				break
 			}
 		}
 	}
 
 	// Create a new tuple with values
-	id, err := insert(r, attributes, insertDecl.Decl[1].Decl, returnedID)
-	if err != nil {
-		return err
+	ids := []int64{}
+	valuesDecl := insertDecl.Decl[1]
+	for _, valueListDecl := range valuesDecl.Decl {
+		// TODO handle all inserts atomically
+		id, err := insert(r, attributes, valueListDecl.Decl, returnedID)
+		if err != nil {
+			return err
+		}
+
+		ids = append(ids, id)
 	}
 
 	// if RETURNING decl is not present
 	if returnedID != "" {
 		conn.WriteRowHeader([]string{returnedID})
-		conn.WriteRow([]string{fmt.Sprintf("%v", id)})
+		for _, id := range ids {
+			conn.WriteRow([]string{fmt.Sprintf("%v", id)})
+		}
 		conn.WriteRowEnd()
 	} else {
-		conn.WriteResult(id, 1)
+		conn.WriteResult(ids[len(ids)-1], (int64)(len(ids)))
 	}
 	return nil
 }

--- a/engine/insert_test.go
+++ b/engine/insert_test.go
@@ -1,0 +1,181 @@
+package engine_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/proullon/ramsql/engine/log"
+
+	_ "github.com/proullon/ramsql/driver"
+)
+
+func TestInsertSingle(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestInsertASingle")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE cat (id INT AUTOINCREMENT, breed TEXT, name TEXT)")
+	if err != nil {
+		t.Fatalf("sql.Exec: Error: %s\n", err)
+	}
+
+	result, err := db.Exec("INSERT INTO cat (breed, name) VALUES ('indeterminate', 'Uhura')")
+	if err != nil {
+		t.Fatalf("Cannot insert into table account: %s", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		t.Fatalf("Cannot check rows affected: %s", err)
+	}
+	if rowsAffected != 1 {
+		t.Fatalf("Expected to affect 1 row, affected %v", rowsAffected)
+	}
+
+	insertedId, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("Cannot check last inserted ID: %s", err)
+	}
+
+	row := db.QueryRow("SELECT breed, name FROM cat WHERE id = ?", insertedId)
+	if row == nil {
+		t.Fatalf("sql.Query failed")
+	}
+
+	var breed string
+	var name string
+	err = row.Scan(&breed, &name)
+	if err != nil {
+		t.Fatalf("row.Scan: %s", err)
+	}
+
+	if breed != "indeterminate" || name != "Uhura" {
+		t.Fatalf("Expected breed 'indeterminate' and name 'Uhura', got breed '%v' and name '%v'", breed, name)
+	}
+}
+
+func TestInsertSingleReturning(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestInsertSingleReturning")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE cat (id INT AUTOINCREMENT, breed TEXT, name TEXT)")
+	if err != nil {
+		t.Fatalf("sql.Exec: Error: %s\n", err)
+	}
+
+	rows, err := db.Query("INSERT INTO cat (breed, name) VALUES ('indeterminate', 'Nala') RETURNING id")
+	if err != nil {
+		t.Fatalf("Cannot insert into table account: %s", err)
+	}
+	defer rows.Close()
+
+	hasRow := rows.Next()
+	if !hasRow {
+		t.Fatalf("Did not return a row: %s", err)
+	}
+
+	var id int
+	err = rows.Scan(&id)
+	if err != nil {
+		t.Fatalf("row.Scan: %s", err)
+	}
+
+	if id != 1 {
+		t.Fatalf("Expected id 1, got id %v", id)
+	}
+
+	hasRow = rows.Next()
+	if hasRow {
+		t.Fatalf("Returned more than one row: %s", err)
+	}
+}
+
+func TestInsertMultiple(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestInsertMultiple")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE cat (id INT AUTOINCREMENT, breed TEXT, name TEXT)")
+	if err != nil {
+		t.Fatalf("sql.Exec: Error: %s\n", err)
+	}
+
+	result, err := db.Exec("INSERT INTO cat (breed, name) VALUES ('persian', 'Mozart'), ('persian', 'Danton')")
+	if err != nil {
+		t.Fatalf("Cannot insert into table account: %s", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		t.Fatalf("Cannot check rows affected: %s", err)
+	}
+	if rowsAffected != 2 {
+		t.Fatalf("Expected to affect 2 rows, affected %v", rowsAffected)
+	}
+}
+
+func TestInsertMultipleReturning(t *testing.T) {
+	log.UseTestLogger(t)
+
+	db, err := sql.Open("ramsql", "TestInsertMultipleReturning")
+	if err != nil {
+		t.Fatalf("sql.Open : Error : %s\n", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE cat (id INT AUTOINCREMENT, breed TEXT, name TEXT)")
+	if err != nil {
+		t.Fatalf("sql.Exec: Error: %s\n", err)
+	}
+
+	rows, err := db.Query("INSERT INTO cat (breed, name) VALUES ('indeterminate', 'Spock'), ('indeterminate', 'Belanna') RETURNING id")
+	if err != nil {
+		t.Fatalf("Cannot insert into table account: %s", err)
+	}
+	defer rows.Close()
+
+	hasRow := rows.Next()
+	if !hasRow {
+		t.Fatalf("Did not return a row: %s", err)
+	}
+
+	var id int
+	err = rows.Scan(&id)
+	if err != nil {
+		t.Fatalf("row.Scan: %s", err)
+	}
+	if id != 1 {
+		t.Fatalf("Expected id 1, got id %v", id)
+	}
+
+	hasRow = rows.Next()
+	if !hasRow {
+		t.Fatalf("Did not return a row: %s", err)
+	}
+
+	err = rows.Scan(&id)
+	if err != nil {
+		t.Fatalf("row.Scan: %s", err)
+	}
+	if id != 2 {
+		t.Fatalf("Expected id 2, got id %v", id)
+	}
+
+	hasRow = rows.Next()
+	if hasRow {
+		t.Fatalf("Returned more than two rows: %s", err)
+	}
+}


### PR DESCRIPTION
The parser used to accept a single `(` token after `VALUES`, and it put values directly beneath the `VALUES` token in the AST. The AST looked like this:

    |-> "INSERT" (InsertToken)
        |-> "INTO" (IntoToken)
            |-> table name
                |-> column name
                |-> (...)
        |-> "VALUES" (ValuesToken)
            |-> value
            |-> (...)
        |-> "RETURNING" (ReturningToken) (optional)
            |-> column name

Now, it nests them in `(` tokens beneath the `VALUES` token, and accepts multiple `(...)` blocks. Now the AST looks like this:

    |-> "INSERT" (InsertToken)
        |-> "INTO" (IntoToken)
            |-> table name
                |-> column name
                |-> (...)
        |-> "VALUES" (ValuesToken)
            |-> "(" (BracketOpeningToken)
                |-> value
                |-> (...)
            |-> (...)
        |-> "RETURNING" (ReturningToken) (optional)
            |-> column name

I also changed the function which handles `INSERT` operations during the execution phase to support multiple value lists, and I added unit tests for that.

Closes #16