### PR TITLE
Support multiple ASC/DESC tokens by ORDER BY

### DIFF
--- a/engine/parser/create.go
+++ b/engine/parser/create.go
@@ -104,6 +104,7 @@ func (p *parser) parseTable(tokens []Token) (*Decl, error) {
 		}
 		tableDecl.Add(newAttribute)
 
+
 		newAttributeType, err := p.parseType()
 		if err != nil {
 			return nil, err

--- a/engine/parser/lexer.go
+++ b/engine/parser/lexer.go
@@ -186,8 +186,6 @@ func (l *lexer) lex(instruction []byte) ([]Token, error) {
 
 	var r bool
 	for l.pos < l.instructionLen {
-		// fmt.Printf("Tokens : %v\n\n", l.tokens)
-
 		r = false
 		for _, m := range matchers {
 			if r = m(); r == true {
@@ -430,6 +428,12 @@ func (l *lexer) MatchNumberToken() bool {
 	i := l.pos
 	for i < l.instructionLen && unicode.IsDigit(rune(l.instruction[i])) {
 		i++
+	}
+	if i < l.instructionLen && l.instruction[i] == '.' {
+		i++
+		for i < l.instructionLen && unicode.IsDigit(rune(l.instruction[i])) {
+			i++
+		}
 	}
 
 	if i != l.pos {

--- a/engine/table.go
+++ b/engine/table.go
@@ -85,6 +85,7 @@ func createTableExecutor(e *Engine, tableDecl *parser.Decl, conn protocol.Engine
 		if err != nil {
 			return err
 		}
+
 		i++
 	}
 


### PR DESCRIPTION
This PR adds support for queries with multiple `ASC/DESC` tokens, for example `SELECT name, surname, age, savings FROM user ORDER BY name ASC, age DESC, savings ASC`. 

It replaces `intOrderer` and `stringOrderer` with a single `genericOrderer`, that way mixing multiple predicates in `sort.Slice` is possible. 

It adds basic internal type support for `int64` and` float64`. 
