### PR TITLE
fix: insert mixed case value attribute

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -31,6 +31,30 @@ func TestCreateTable(t *testing.T) {
 	}
 }
 
+func TestInsertBool(t *testing.T) {
+
+	db, err := sql.Open("ramsql", "TestInsertBool")
+	if err != nil {
+		t.Fatalf("sql.Open: %s", err)
+	}
+
+	_, err = db.Exec(`CREATE TABLE ttable (id BIGINT, hasBool BOOL)`)
+	if err != nil {
+		t.Fatalf("cannot create table: %s", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO ttable (id, hasBool) VALUES (?,?)`, 1, true)
+	if err != nil {
+		t.Fatalf("cannot insert into table: %s", err)
+	}
+
+	err = db.Close()
+	if err != nil {
+		t.Fatalf("sql.Close : Error : %s\n", err)
+	}
+
+}
+
 func TestInsertEmptyString(t *testing.T) {
 
 	db, err := sql.Open("ramsql", "TestInsertEmptyString")

--- a/engine/executor/engine.go
+++ b/engine/executor/engine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/proullon/ramsql/engine/agnostic"
 	"github.com/proullon/ramsql/engine/log"
@@ -360,7 +361,7 @@ func getValues(specifiedAttrs []string, valuesDecl *parser.Decl, args []NamedVal
 				return nil, err
 			}
 		}
-		values[specifiedAttrs[i]] = v
+		values[strings.ToLower(specifiedAttrs[i])] = v
 	}
 
 	return values, nil


### PR DESCRIPTION
## Context

Mixed case variable are not recognized by agnostic engine value map. 

## Fix

`executor` engine store variable as `strings.ToLower` in values map.

Closes #82 
