### PR TITLE
fix(engine): Relation.Attribute() convert name argument to lower case

### DIFF
--- a/engine/agnostic/relation.go
+++ b/engine/agnostic/relation.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -57,6 +58,7 @@ func NewRelation(schema, name string, attributes []Attribute, pk []string) (*Rel
 }
 
 func (r *Relation) Attribute(name string) (int, Attribute, error) {
+	name = strings.ToLower(name)
 	index, ok := r.attrIndex[name]
 	if !ok {
 		return 0, Attribute{}, errors.New("attribute not defined")


### PR DESCRIPTION
Resolves https://github.com/proullon/ramsql/issues/86